### PR TITLE
Create README.md with status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# wirebrush
+
+[![ci](https://github.com/gememma/wirebrush/actions/workflows/ci.yml/badge.svg)](https://github.com/gememma/wirebrush/actions/workflows/ci.yml)


### PR DESCRIPTION
Now that we have a GitHub Actions workflow (#11) we can put a status badge in the README that shows the status of the workflow.