### PR TITLE
Replace the removed lockfile check with a working one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,9 @@ jobs:
         components: rustfmt
     - name: Cache files
       uses: Swatinem/rust-cache@v2
-    - name: Check Cargo.lock
-      run: cargo update --locked
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --locked
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --locked
     - name: Check formatting
       run: cargo fmt --check


### PR DESCRIPTION
Instead of running `cargo update --locked` like before, now we're just adding the `--locked` flag to `cargo build` and `cargo test`. This produces the behaviour we want: if the contents of the lockfile are out-of-date with what `cargo build` (or `cargo test`) would produce, the command fails. In contrast to `cargo update --locked`, this catches lockfiles that don't include information about added or deleted dependencies, or version changes as declared in `Cargo.toml`, but does _not_ check whether the resolved versions in the lockfile are the most up-to-date versions of each package.