### PR TITLE
Make content and static paths overridable, add Nix packages for them

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,30 @@
       packages = rec {
         default = wirebrush;
         wirebrush = (rustPkgs.workspace.wirebrush { }).bin;
+
+        content = pkgs.stdenv.mkDerivation {
+          name = "wirebrush-content";
+          src = ./content;
+
+          phases = "installPhase";
+
+          installPhase = ''
+            mkdir -p $out
+            cp -vrf $src/* $out
+          '';
+        };
+
+        static = pkgs.stdenv.mkDerivation {
+          name = "wirebrush-static";
+          src = ./static;
+
+          phases = "installPhase";
+
+          installPhase = ''
+            mkdir -p $out
+            cp -vrf $src/* $out
+          '';
+        };
       };
 
       apps = rec {


### PR DESCRIPTION
This was breaking the deployment, because the app expected to be able to find `./content` and `./static` at runtime. These changes will allow me to deploy wirebrush properly by building the two new separate packages (one for each) and pointing the app at them at runtime.