### PR TITLE
Add aarch64-linux to Nix supported systems list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
 
       supportedSystems = with flake-utils.lib.system; [
         aarch64-darwin
+        aarch64-linux
         x86_64-darwin
         x86_64-linux
       ];


### PR DESCRIPTION
This is necessary in order to deploy `wirebrush` to an arm64 NixOS server.